### PR TITLE
Fix getBrowser on Chrome for Android

### DIFF
--- a/BMSPushSDK.js
+++ b/BMSPushSDK.js
@@ -288,7 +288,7 @@ function BMSPush() {
     const SERVICE_WORKER = 'BMSPushServiceWorker.js';
 
     function getBrowser() {
-      if (window.navigator.userAgent.indexOf("Chrome") != -1 && chrome.runtime.getManifest) {
+      if (window.navigator.userAgent.indexOf("Chrome") != -1 && chrome.runtime && chrome.runtime.getManifest) {
         return CHROME_EXTENSION;
       }
       let userAgentOfBrowser = navigator.userAgent.toLowerCase();


### PR DESCRIPTION
On my Android in Chrome(60.0.3112.107) there's no such variable as chrome.runtime, what causes an error.